### PR TITLE
Contractor /reschedule

### DIFF
--- a/src/main/kotlin/dev/scroogemcfawk/manicurebot/config/Locale.kt
+++ b/src/main/kotlin/dev/scroogemcfawk/manicurebot/config/Locale.kt
@@ -20,12 +20,21 @@ data class Locale(
     val cancelCommand: String = "cancel",
     val rescheduleCommand: String = "reschedule",
 
+    val rescheduleCommandShort: String = "r",
+    val rescheduleContractorShowAppointmentsToRescheduleToAction: String = "1",
+
     val registerUserNamePromptMessage: String = "Please, enter your name:",
     val registerUserPhonePromptMessage: String = "Please, enter your phone number:",
     val registerSuccessfulRegistrationMessageTemplate: String = "Done. You can now signup for appointments.",
     val registerUserAlreadyExistsMessage: String = "You are already registered.",
 
     val rescheduleDoneMessageTemplate: String = "Your appointment rescheduled from $1 to $2.",
+    val rescheduleYouDontHaveAppointmentMessage: String = "You do not have any appointments.",
+    val rescheduleChooseAppointmentToRescheduleToPromptMessage: String =
+        "Choose an appointment to reschedule to:",
+    val rescheduleNoAppointmentsAvailableMessage: String = "No appointments available.",
+    val rescheduleContractorChooseAppointmentToReschedulePromptMessage: String =
+        "Choose an appointment you want to reschedule:",
 
     val appointmentNotRegisteredMessageTemplate: String = "You are not registered. Please register using /$1 command.",
     val appointmentNotAlreadyTakenMessage: String = "Appointment is not available.",

--- a/src/main/kotlin/dev/scroogemcfawk/manicurebot/domain/AppointmentList.kt
+++ b/src/main/kotlin/dev/scroogemcfawk/manicurebot/domain/AppointmentList.kt
@@ -1,6 +1,7 @@
 package dev.scroogemcfawk.manicurebot.domain
 
 import dev.scroogemcfawk.manicurebot.isFuture
+import korlibs.time.DateTime
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -10,8 +11,11 @@ class AppointmentList(
     private val dateTimeFormat = DateTimeFormatter.ofPattern(dateTimePattern)
     private val appointments = ArrayList<Appointment>()
 
-    val all: ArrayList<Appointment>
+    val all: List<Appointment>
         get() = this.appointments
+
+    val allFuture: List<Appointment>
+        get() = this.appointments.filter { it.datetime > LocalDateTime.now() }
 
     fun add(a: Appointment) {
         appointments.add(a)
@@ -50,7 +54,7 @@ class AppointmentList(
         return false
     }
 
-    fun assignClient(a: Appointment, id: Long) {
+    fun assignClient(a: Appointment, id: Long?) {
         for (e in appointments) {
             if (e == a) {
                 e.client = id
@@ -86,8 +90,8 @@ class AppointmentList(
 
     fun reschedule(old: Appointment, new: Appointment): Boolean {
         if (isAvailable(new)) {
-            assignClient(new, old.client!!)
-            old.client = null
+            assignClient(new, old.client)
+            assignClient(old, null)
             return true
         }
         return false

--- a/src/main/kotlin/dev/scroogemcfawk/manicurebot/keyboards/AppointmentListInline.kt
+++ b/src/main/kotlin/dev/scroogemcfawk/manicurebot/keyboards/AppointmentListInline.kt
@@ -1,0 +1,33 @@
+package dev.scroogemcfawk.manicurebot.keyboards
+
+import dev.inmo.tgbotapi.types.ChatId
+import dev.inmo.tgbotapi.types.buttons.InlineKeyboardButtons.InlineKeyboardButton
+import dev.inmo.tgbotapi.types.buttons.InlineKeyboardMarkup
+import dev.inmo.tgbotapi.types.buttons.inline.dataInlineButton
+import dev.inmo.tgbotapi.utils.MatrixBuilder
+import dev.inmo.tgbotapi.utils.RowBuilder
+import dev.scroogemcfawk.manicurebot.domain.AppointmentList
+import java.time.format.DateTimeFormatter
+
+fun getAppointmentListInlineMarkup(
+    chatId: Long,
+    appointments: AppointmentList,
+    dateTimeFormat: DateTimeFormatter,
+    callbackBase: String
+): InlineKeyboardMarkup {
+
+    val mb = MatrixBuilder<InlineKeyboardButton>()
+
+    for (a in appointments.allFuture.filter { it.client == chatId }) {
+        val rb = RowBuilder<InlineKeyboardButton>()
+        rb.add(
+            dataInlineButton(
+                a.datetime.format(dateTimeFormat),
+                "${callbackBase}:${a.toCallbackString()}"
+            )
+        )
+        mb.add(rb.row)
+    }
+
+    return InlineKeyboardMarkup(mb.matrix)
+}


### PR DESCRIPTION
ADD: "reschedule appointment" behavior to /reschedule as Contractor,
UPD: fixed bug in AppointmentList.reschedule(), now reassigns clients for both old and new appointments.

closes #4